### PR TITLE
Switch go license collector tool + some minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _bin/
 repos-cache/
 output.txt
 log.txt
+logs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _bin/
 repos-cache/
 output.txt
+log.txt

--- a/README.md
+++ b/README.md
@@ -17,13 +17,16 @@ export GITHUB_PERSONAL_ACCESS_TOKEN='..Personal Access Token..'
 Now you can run the `collect` command to collect all the repos of a specified GitHub Organization and then collect the licenses for all of those repos:
 
 ```
-github-license-collector collect --org=GitHubOrgName
+go install && github-license-collector collect --org=GitHubOrgName | tee log.txt
 ```
 
 ### Requirements
+
+- Go: `cd /tmp && go install -v github.com/google/go-licenses@master && cd -`
 - Node 10, `brew install node@10`
 - Yarn, `npm install -g yarn`
 - Get go packages, `go get ./...`
+- `tee` if you want to use the `tee` command in the example
 
 ### Analyzers
 

--- a/analyzers/golang/golang.go
+++ b/analyzers/golang/golang.go
@@ -2,13 +2,14 @@ package golang
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/bitrise-io/github-license-collector/analyzers"
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/errorutil"
-	lic "github.com/godrei/licenses/licenses"
 )
 
 type Analyzer struct {
@@ -33,7 +34,8 @@ func (a *Analyzer) Detect(repoURL, localSourcePath string) (bool, error) {
 }
 
 func (a Analyzer) AnalyzeRepository() (analyzers.RepositoryLicenseInfos, error) {
-	out, err := command.New("go", "get", "./...").SetDir(a.localSourcePath).AppendEnvs("GOPATH=" + os.Getenv("TMP_GOPATH")).RunAndReturnTrimmedCombinedOutput()
+	cmd := command.New("go-licenses", "csv", ".").SetDir(a.localSourcePath)
+	out, err := cmd.RunAndReturnTrimmedOutput()
 	if err != nil {
 		if errorutil.IsExitStatusError(err) {
 			return analyzers.RepositoryLicenseInfos{}, errors.New(out)
@@ -41,24 +43,31 @@ func (a Analyzer) AnalyzeRepository() (analyzers.RepositoryLicenseInfos, error) 
 		return analyzers.RepositoryLicenseInfos{}, err
 	}
 
-	licensesByPackage, err := lic.Licenses(os.Getenv("TMP_GOPATH"), a.localSourcePath)
+	licences, err := csvToLicenseInfos(out)
 	if err != nil {
 		return analyzers.RepositoryLicenseInfos{}, err
-	}
-
-	var licences []analyzers.LicenseInfo
-	for p, l := range licensesByPackage {
-		licence := analyzers.LicenseInfo{
-			LicenseType: l,
-			Dependency:  p,
-		}
-		licences = append(licences, licence)
 	}
 
 	return analyzers.RepositoryLicenseInfos{
 		RepositoryURL: a.repoURL,
 		Licenses:      licences,
-	}, err
+	}, nil
+}
+
+func csvToLicenseInfos(csv string) ([]analyzers.LicenseInfo, error) {
+	licenses := []analyzers.LicenseInfo{}
+	for _, line := range strings.Split(csv, "\n") {
+		csvParts := strings.Split(line, ",")
+		// NOTE: a csv line should include 3 components (see https://github.com/google/go-licenses):
+		// 1.: dependency/package name (URL) (e.g. "https://github.com/grpc/grpc-go/blob/master/LICENSE")
+		// 2.: the license's URL (a remote URL to the license file, if any) (e.g. "google.golang.org/grpc")
+		// 3.: the type ID of the license (e.g. "Apache-2.0")
+		if len(csvParts) != 3 {
+			return []analyzers.LicenseInfo{}, fmt.Errorf("invalid CSV line (number of csv parts != 3) : %s", csv)
+		}
+		licenses = append(licenses, analyzers.LicenseInfo{Dependency: csvParts[0], LicenseType: csvParts[2]})
+	}
+	return licenses, nil
 }
 
 func getGoDepDescrptors(repoPath string) ([]string, error) {

--- a/analyzers/golang/golang_test.go
+++ b/analyzers/golang/golang_test.go
@@ -1,0 +1,54 @@
+package golang
+
+import (
+	"testing"
+
+	"github.com/bitrise-io/github-license-collector/analyzers"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_csvToLicenseInfos(t *testing.T) {
+	t.Log("single line csv")
+	{
+		licenses, err := csvToLicenseInfos(`google.golang.org/grpc,https://github.com/grpc/grpc-go/blob/master/LICENSE,Apache-2.0`)
+		require.NoError(t, err)
+		require.Equal(t, licenses,
+			[]analyzers.LicenseInfo{
+				{
+					LicenseType: "Apache-2.0",
+					Dependency:  "google.golang.org/grpc",
+				},
+			})
+	}
+	t.Log("multi line csv")
+	{
+		csv := `google.golang.org/grpc,https://github.com/grpc/grpc-go/blob/master/LICENSE,Apache-2.0
+go.opencensus.io,https://github.com/census-instrumentation/opencensus-go/blob/master/LICENSE,Apache-2.0`
+		licenses, err := csvToLicenseInfos(csv)
+		require.NoError(t, err)
+		require.Equal(t, licenses,
+			[]analyzers.LicenseInfo{
+				{
+					LicenseType: "Apache-2.0",
+					Dependency:  "google.golang.org/grpc",
+				},
+				{
+					LicenseType: "Apache-2.0",
+					Dependency:  "go.opencensus.io",
+				},
+			})
+	}
+
+	// --- Error tests ---
+	{
+		licenses, err := csvToLicenseInfos("")
+		require.EqualError(t, err, "invalid CSV line (number of csv parts != 3) : ")
+		require.Equal(t, licenses, []analyzers.LicenseInfo{})
+	}
+
+	{
+		licenses, err := csvToLicenseInfos(`one,two`)
+		require.EqualError(t, err, "invalid CSV line (number of csv parts != 3) : one,two")
+		require.Equal(t, licenses, []analyzers.LicenseInfo{})
+	}
+}

--- a/analyzers/npm/npm.go
+++ b/analyzers/npm/npm.go
@@ -3,7 +3,6 @@ package npm
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,12 +47,8 @@ func (a *Analyzer) Detect(repoURL, localSourcePath string) (bool, error) {
 }
 
 func (a *Analyzer) AnalyzeRepository() (analyzers.RepositoryLicenseInfos, error) {
-	if err := os.Chdir(a.localSourcePath); err != nil {
-		return analyzers.RepositoryLicenseInfos{}, fmt.Errorf("change to source dir %s: %s", a.localSourcePath, err)
-	}
-
-	cmd := command.New("yarn", "licenses", "list", "--json", "--no-progress")
-	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
+	cmd := command.New("yarn", "licenses", "list", "--json", "--no-progress").SetDir(a.localSourcePath)
+	out, err := cmd.RunAndReturnTrimmedOutput()
 	if err != nil {
 		if errorutil.IsExitStatusError(err) {
 			return analyzers.RepositoryLicenseInfos{}, errors.New(out)

--- a/analyzers/npm/npm_test.go
+++ b/analyzers/npm/npm_test.go
@@ -1,0 +1,69 @@
+package npm
+
+import (
+	"testing"
+
+	"github.com/bitrise-io/github-license-collector/analyzers"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_npmJSONsToLicenseInfos(t *testing.T) {
+	t.Log("single line OK")
+	{
+		npmJSONs := `{"type":"table","data":{"head":["Name","Version","License","URL","VendorUrl","VendorName"],"body":[["@algolia/cache-browser-local-storage","4.11.0","MIT","git://github.com/algolia/algoliasearch-client-javascript.git","Unknown","Unknown"],["@algolia/cache-common","4.11.0","MIT","git://github.com/algolia/algoliasearch-client-js.git","Unknown","Unknown"]]}}`
+		licenses, err := npmJSONsToLicenseInfos(npmJSONs)
+		require.NoError(t, err)
+		require.Equal(t,
+			[]analyzers.LicenseInfo{
+				{
+					LicenseType: "MIT",
+					Dependency:  "@algolia/cache-browser-local-storage",
+				},
+				{
+					LicenseType: "MIT",
+					Dependency:  "@algolia/cache-common",
+				},
+			}, licenses)
+	}
+	t.Log("multi line OK")
+	{
+		npmJSONs := `{"type":"warning","data":"@bitrise/bitkit > react-popper > popper.js@1.16.1: You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1"}
+{"type":"warning","data":"webpack > watchpack > watchpack-chokidar2 > chokidar@2.1.8: Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies."}
+{"type":"table","data":{"head":["Name","Version","License","URL","VendorUrl","VendorName"],"body":[["@algolia/cache-browser-local-storage","4.11.0","MIT","git://github.com/algolia/algoliasearch-client-javascript.git","Unknown","Unknown"],["@algolia/cache-common","4.11.0","MIT","git://github.com/algolia/algoliasearch-client-js.git","Unknown","Unknown"]]}}
+`
+		licenses, err := npmJSONsToLicenseInfos(npmJSONs)
+		require.NoError(t, err)
+		require.Equal(t,
+			[]analyzers.LicenseInfo{
+				{
+					LicenseType: "MIT",
+					Dependency:  "@algolia/cache-browser-local-storage",
+				},
+				{
+					LicenseType: "MIT",
+					Dependency:  "@algolia/cache-common",
+				},
+			}, licenses)
+	}
+
+	// --- Error tests ---
+	{
+		licenses, err := npmJSONsToLicenseInfos("")
+		require.EqualError(t, err, "no license information provided by yarn")
+		require.Equal(t, licenses, []analyzers.LicenseInfo{})
+	}
+
+	t.Log("invalid JSON")
+	{
+		licenses, err := npmJSONsToLicenseInfos(`{"not-a-valid-json":[}`)
+		require.EqualError(t, err, "no license information provided by yarn")
+		require.Equal(t, licenses, []analyzers.LicenseInfo{})
+	}
+
+	{
+		npmJSONs := `{"type":"table","data":{"head":["Name","Version","License","URL","VendorUrl","VendorName"],"body":[]}}`
+		licenses, err := npmJSONsToLicenseInfos(npmJSONs)
+		require.EqualError(t, err, "0 license information found")
+		require.Equal(t, licenses, []analyzers.LicenseInfo{})
+	}
+}

--- a/cmd/collect.go
+++ b/cmd/collect.go
@@ -235,14 +235,18 @@ func collect(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Println()
+	fmt.Fprintln(outputFile)
 
 	log.Infof("licence types (# of dependency uses):")
+	fmt.Fprintf(outputFile, "licence types (# of dependency uses):\n")
 	allLicenceUsage := 0
 	for lType, used := range licenceTypes {
 		log.Printf("- %s: %d", lType, used)
+		fmt.Fprintf(outputFile, "- %s: %d\n", lType, used)
 		allLicenceUsage += used
 	}
 	log.Printf("%d licences used", allLicenceUsage)
+	fmt.Fprintf(outputFile, "%d licences used\n", allLicenceUsage)
 	return nil
 }
 


### PR DESCRIPTION
- switch from github.com/godrei/licenses/licenses to github.com/google/go-licenses
- error handling fix in npm analyzer
- added "licence types" summary to the generated output.txt
- added some tests for the golang licence analyzer